### PR TITLE
Remove unused fitness_all variable

### DIFF
--- a/matlab/acpso_lstm.m
+++ b/matlab/acpso_lstm.m
@@ -67,16 +67,12 @@ end
 for iter = 1:maxIter
     w = w_max - (w_max - w_min) * iter / maxIter;
 
-    fitness_all = zeros(nParticles, 1);
     gbest_candidates = zeros(nParticles, nDim);
     gbest_fit_candidates = inf(nParticles, 1);
 
     parfor i = 1:nParticles
         params_real = lb + X(i,:) .* (ub - lb);
         [fitness, ~, ~] = runLSTM(params_real, filename);
-
-        fitness_all(i) = fitness;
-
         if fitness < pbest_fitness(i)
             pbest(i,:) = X(i,:);
             pbest_fitness(i) = fitness;


### PR DESCRIPTION
## Summary
- drop unused `fitness_all` variable assignment from `acpso_lstm`

## Testing
- `octave matlab/acpso_lstm.m` *(fails: command not found)*
- `matlab -batch "acpso_lstm('data.xlsx')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f0f0de6648326bbc17a0d2950dedd